### PR TITLE
Fix: Env Name

### DIFF
--- a/pkg/stackbuilder/stackbuilder.go
+++ b/pkg/stackbuilder/stackbuilder.go
@@ -41,7 +41,7 @@ func NewEnvironments(value cue.Value) (Environments, error) {
 	}
 
 	for envIter.Next() {
-		name := utils.GetLastPathFragment(envIter.Value())
+		name := strings.Trim(utils.GetLastPathFragment(envIter.Value()), "\"")
 		environments[name], err = NewStackBuilder(name, envIter.Value())
 		if err != nil {
 			return environments, err


### PR DESCRIPTION
- Environment fails to build if it contains double quotes