### PR TITLE
Fix/small compose improvements

### DIFF
--- a/pkg/drivers/compose.go
+++ b/pkg/drivers/compose.go
@@ -57,10 +57,14 @@ func (d *ComposeDriver) ApplyAll(stack *stack.Stack, stdout bool) error {
 	}
 
 	if _, err := os.Stat(d.Config.Output.Dir); os.IsNotExist(err) {
-		os.MkdirAll(d.Config.Output.Dir, 0700)
+		if err := os.MkdirAll(d.Config.Output.Dir, 0700); err != nil {
+			return err
+		}
 	}
 	filePath := path.Join(d.Config.Output.Dir, d.Config.Output.File)
-	os.WriteFile(filePath, data, 0600)
+	if err := os.WriteFile(filePath, data, 0600); err != nil {
+		return err
+	}
 
 	log.Infof("[compose] applied resources to \"%s\"", filePath)
 

--- a/pkg/drivers/compose.go
+++ b/pkg/drivers/compose.go
@@ -60,7 +60,7 @@ func (d *ComposeDriver) ApplyAll(stack *stack.Stack, stdout bool) error {
 		os.MkdirAll(d.Config.Output.Dir, 0700)
 	}
 	filePath := path.Join(d.Config.Output.Dir, d.Config.Output.File)
-	os.WriteFile(filePath, data, 0700)
+	os.WriteFile(filePath, data, 0600)
 
 	log.Infof("[compose] applied resources to \"%s\"", filePath)
 


### PR DESCRIPTION
A couple of small improvements to the compose driver:

- Don't make `docker-compose.yaml` executable (unnecessary)
- Handle errors on `os.MkdirAll` and `os.WriteFile`